### PR TITLE
Add AppName as input to n8n template

### DIFF
--- a/n8n/.microtica/template.yaml
+++ b/n8n/.microtica/template.yaml
@@ -3,8 +3,19 @@ description: n8n helps you to interconnect every app with an API.
 logo: https://microtica.s3.eu-central-1.amazonaws.com/assets/templates/logos/n8n.png
 repo: https://github.com/microtica/templates/tree/master/n8n
 
+inputs:
+  properties:
+    AppName:
+      type: string
+      description: The name of the application. The name will be shown in the portal.
+      maxLength: 23
+      pattern: ^[a-z]*$
+      patternErrorMessage: "The app name can contain only lowercase letters."
+  required:
+    - AppName
+
 service:
-  n8n:
+  "{{AppName}}":
     source: git
     containerPort: 5678
     autoScaling:


### PR DESCRIPTION
This was the only template without an AppName input param which was used to find the service name from the build steps and to add the DONE step when the deployment finished.
Jira issue: https://microtica.atlassian.net/browse/MIC-1377
